### PR TITLE
Recognizes Rules As Already Nested If `hover:hover` Misses The Space Char

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = ({
     while (container !== null && container.type !== 'root') {
       if (
         container.type === 'atrule' &&
-        container.params.includes('hover: hover')
+        (container.params.includes('hover: hover') || container.params.includes('hover:hover'))
       ) {
         return true
       }

--- a/index.test.js
+++ b/index.test.js
@@ -62,6 +62,18 @@ describe('basic usage', () => {
     )
   })
 
+  it('skips rules contained within `@media (hover:hover) {}` - no space used', () => {
+    run(
+      '@media (hover:hover) {.btn:hover {}}',
+      '@media (hover:hover) {.btn:hover {}}'
+    )
+
+    run(
+      '.p-index { @media (hover:hover) {.btn:hover {}} }',
+      '.p-index { @media (hover:hover) {.btn:hover {}} }'
+    )
+  })
+
   it('works with pseudo-class functions that accept selector lists as an argument', () => {
     run(
       ':is(button, [role="button"]):hover { background-color: transparent; }',


### PR DESCRIPTION
This library does not add a media query if it is already present:
`@media (hover: hover) {.btn:hover {}}`

But if there is NO SPACE between `hover:` and `hover` like this:
`@media (hover:hover) {.btn:hover {}}`

...then we get:
`@media (hover:hover) { @media (hover: hover) {.btn:hover {}}}`

I found a case in the [DaisyUI code](https://github.com/saadeghi/daisyui/blob/master/src/components/unstyled/breadcrumbs.css#L10) where they cannot use a space and hence I suspect that this scenario is relevant in more cases than just this one.