### PR TITLE
fix: infinite loop when :hover is contained in :has or nested :not selector

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,16 @@ const selectorProcessor = selectorParser(selectors => {
     if (
       selector.type === 'pseudo' &&
       selector.toString() === ':hover' &&
-      selector.parent.value !== ':not' &&
       selector.parent.toString() !== ':hover'
     ) {
+      let parent = selector.parent
+      while (parent !== undefined) {
+        if (parent.value === ':has' || parent.value === ':not') {
+          return
+        }
+
+        parent = parent.parent
+      }
       hoverSelectors.push(selector.parent.toString())
     }
   })

--- a/index.test.js
+++ b/index.test.js
@@ -75,6 +75,20 @@ describe('basic usage', () => {
       '.list__item:not(:hover, .is-editing) .show-on-hover { visibility: hidden }'
     )
   })
+
+  it('ignores nested :hover pseudo-class selectors within :not pseudo-class selector lists', () => {
+    run(
+      '.list__item:not(.some-selector:hover) .show-on-hover { visibility: hidden }',
+      '.list__item:not(.some-selector:hover) .show-on-hover { visibility: hidden }'
+    )
+  })
+
+  it('ignores :hover pseudo-class selectors within :has pseudo-class selector lists', () => {
+    run(
+      '.list__item:has(.some-selector:hover) .show-on-hover { visibility: hidden }',
+      '.list__item:has(.some-selector:hover) .show-on-hover { visibility: hidden }'
+    )
+  })
 })
 
 describe('when `fallback: true`', () => {


### PR DESCRIPTION
The previous fix for `:not()` in 3433c7da7bf759ea435681ad3bd3e13f5c99375e was incomplete because it only considered `:hover` as a standalone selector but missed the ability to combine it with other selectors like `:not(.some-class:hover)`, yielding an infinite loop once again.

The same problem exists for `:has()` and since it follows the same semantics, I went ahead and unified the approach for both pseudo selectors. For complex selectors the `:not()` or `:has()` is not the immediate parent, requiring a recursive lookup to identify any such selectors.

Fixes #35